### PR TITLE
Make the application runnable in UNIX.

### DIFF
--- a/Audio/MockSongPlayer.cs
+++ b/Audio/MockSongPlayer.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Jammit.Model;
+using NAudio.Wave;
+
+namespace Jammit.Audio
+{
+  public class MockSongPlayer : ISongPlayer
+  {
+    private TimeSpan _position;
+    private PlaybackState _playbackState;
+    private readonly WaveMixerStream32 _mixer;
+
+    public MockSongPlayer(ISong s)
+    {
+      _mixer = new WaveMixerStream32();
+      _mixer.AddInputStream(new WaveChannel32(new ClickTrackStream(s.Beats)));
+    }
+
+    #region ISongPlayer members
+
+    public void Play()
+    {
+      _playbackState = PlaybackState.Playing;
+    }
+
+    public void Pause()
+    {
+      _playbackState = PlaybackState.Paused;
+    }
+
+    public void Stop()
+    {
+      _playbackState = PlaybackState.Stopped;
+    }
+
+    public long PositionSamples => _position.Ticks / 8;
+
+    public TimeSpan Position
+    {
+      get { return _position; }
+      set { _position = value; }
+    }
+
+    public TimeSpan Length => _mixer.TotalTime;
+
+    public PlaybackState State => _playbackState;
+
+    public int Channels => 0;
+
+    public string GetChannelName(int channel) => $"Mock Channel[{channel}]";
+
+    public void SetChannelVolume(int channel, float volume) { }
+
+    public float GetChannelVolume(int channel) => 0.0f;
+
+    #endregion
+  }
+}

--- a/Jam.NET.csproj
+++ b/Jam.NET.csproj
@@ -163,6 +163,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Compile Include="Audio\MockSongPlayer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config">

--- a/Jam.NET.sln
+++ b/Jam.NET.sln
@@ -19,4 +19,38 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		Policies = $0
+		$0.DotNetNamingPolicy = $1
+		$1.DirectoryNamespaceAssociation = None
+		$1.ResourceNamePolicy = FileFormatDefault
+		$0.TextStylePolicy = $2
+		$2.FileWidth = 120
+		$2.TabWidth = 2
+		$2.IndentWidth = 2
+		$2.inheritsSet = VisualStudio
+		$2.inheritsScope = text/plain
+		$2.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $3
+		$3.IndentSwitchSection = True
+		$3.NewLinesForBracesInProperties = True
+		$3.NewLinesForBracesInAccessors = True
+		$3.NewLinesForBracesInAnonymousMethods = True
+		$3.NewLinesForBracesInControlBlocks = True
+		$3.NewLinesForBracesInAnonymousTypes = True
+		$3.NewLinesForBracesInObjectCollectionArrayInitializers = True
+		$3.NewLinesForBracesInLambdaExpressionBody = True
+		$3.NewLineForElse = True
+		$3.NewLineForCatch = True
+		$3.NewLineForFinally = True
+		$3.NewLineForMembersInObjectInit = True
+		$3.NewLineForMembersInAnonymousTypes = True
+		$3.NewLineForClausesInQuery = True
+		$3.SpacingAfterMethodDeclarationName = False
+		$3.SpaceAfterMethodCallName = False
+		$3.SpaceBeforeOpenSquareBracket = False
+		$3.inheritsSet = Mono
+		$3.inheritsScope = text/x-csharp
+		$3.scope = text/x-csharp
+	EndGlobalSection
 EndGlobal

--- a/Model/FolderSong.cs
+++ b/Model/FolderSong.cs
@@ -81,6 +81,9 @@ namespace Jammit.Model
 
     public ISongPlayer GetSongPlayer()
     {
+      if (System.Type.GetType("Mono.Runtime") != null)
+        return new MockSongPlayer(this);
+
       return new JammitNAudioSongPlayer(this);
     }
 

--- a/Model/ZipSong.cs
+++ b/Model/ZipSong.cs
@@ -87,6 +87,9 @@ namespace Jammit.Model
 
     public ISongPlayer GetSongPlayer()
     {
+      if (System.Type.GetType("Mono.Runtime") != null)
+        return new MockSongPlayer(this);
+
       return new JammitNAudioSongPlayer(this);
     }
 


### PR DESCRIPTION
This change implements a MuteNAudioSongPlayer, which mocks lacks any _waveform member or implementation.

Works on Mac OS X (10.2) and Linux (Ubuntu).

The song will successfully load and display controls and score, but the 'Play' functionality is just a placeholder for now.
![screenshot from 2017-03-06 00-15-59](https://cloud.githubusercontent.com/assets/4507319/23604564/30c45d96-020e-11e7-938c-d5378297fe60.png)
![screenshot from 2017-03-06 00-16-59](https://cloud.githubusercontent.com/assets/4507319/23604589/38126390-020e-11e7-975c-a75a925f36c3.png)
![screenshot from 2017-03-06 00-34-46](https://cloud.githubusercontent.com/assets/4507319/23604595/3ca7e4d4-020e-11e7-9789-1ed038916939.png)


Note: class MockSongPlayer was also implemented, but its usage broke the app due to indexing errors related to some control's Max and Min values.