### PR TITLE
Add local Nuget.Config.

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositoryPath" value="packages" />
+  </config>
+</configuration>


### PR DESCRIPTION
System-wide NuGet configuration might conflict with the default `repositoryPath` value (packages\).