### PR TITLE
Create Cache dir if it doesn't exist.

### DIFF
--- a/Desktop/Model/Library.cs
+++ b/Desktop/Model/Library.cs
@@ -124,6 +124,10 @@ namespace Jammit.Model
         }
       }
 
+      string cacheDir = Path.GetDirectoryName(CacheFileName);
+      if (!Directory.Exists(cacheDir))
+        Directory.CreateDirectory(cacheDir);
+
       using (var s = File.OpenWrite(CacheFileName))
       {
         cacheDoc.Save(s);


### PR DESCRIPTION
If %localappdata%\Jam.NET directory doesn't exists, the app crashes.
This change creates the directory before attempting to write the cache file.