### PR TITLE
Read the right prefix for ZIP entries.

### DIFF
--- a/Core/Model/SongMeta.cs
+++ b/Core/Model/SongMeta.cs
@@ -72,7 +72,7 @@ namespace Jammit.Model
           if (e.FullName.EndsWith(".jcf/") || Regex.IsMatch(e.FullName, @".*-.*-.*-.*/"))
           {
             id = Guid.Parse(e.FullName.Substring(0, 36));
-            entryPath = e.FullName;
+            entryPath = e.FullName.Substring(0, e.FullName.IndexOf('/') + 1);
             break;
           }
         }


### PR DESCRIPTION
Matching ZIP file entries may sometimes not be the root JCF directory, but JCF content files, thus generating an exception and making the ZIP song "invisible" to the scan.

This change ensures the prefix is strictly the root JCF path.